### PR TITLE
Add diffblue unit tests

### DIFF
--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsMessageUtilTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsMessageUtilTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.StringUtil;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+import java.lang.reflect.Method;
+
+public class DnsMessageUtilTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Rule public final Timeout globalTimeout = new Timeout(10000);
+
+  /* testedClasses: DnsMessageUtil */
+  // Test written by Diffblue Cover.
+  @Test
+  public void appendRecordClassInputNotNullPositiveOutputNotNull() {
+
+    // Arrange
+    final StringBuilder buf = new StringBuilder("?");
+    final int dnsClass = 7;
+
+    // Act
+    final StringBuilder actual = DnsMessageUtil.appendRecordClass(buf, dnsClass);
+
+    // Assert side effects
+    Assert.assertNotNull(buf);
+    Assert.assertEquals("?UNKNOWN(7)", buf.toString());
+
+    // Assert result
+    Assert.assertNotNull(actual);
+    Assert.assertEquals("?UNKNOWN(7)", actual.toString());
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void appendRecordClassInputNotNullPositiveOutputNotNull2() {
+
+    // Arrange
+    final StringBuilder buf = new StringBuilder("?");
+    final int dnsClass = 254;
+
+    // Act
+    final StringBuilder actual = DnsMessageUtil.appendRecordClass(buf, dnsClass);
+
+    // Assert side effects
+    Assert.assertNotNull(buf);
+    Assert.assertEquals("?NONE", buf.toString());
+
+    // Assert result
+    Assert.assertNotNull(actual);
+    Assert.assertEquals("?NONE", actual.toString());
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void appendRecordClassInputNotNullPositiveOutputNotNull3() {
+
+    // Arrange
+    final StringBuilder buf = new StringBuilder("???");
+    final int dnsClass = 1;
+
+    // Act
+    final StringBuilder actual = DnsMessageUtil.appendRecordClass(buf, dnsClass);
+
+    // Assert side effects
+    Assert.assertNotNull(buf);
+    Assert.assertEquals("???IN", buf.toString());
+
+    // Assert result
+    Assert.assertNotNull(actual);
+    Assert.assertEquals("???IN", actual.toString());
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void appendRecordClassInputNotNullPositiveOutputNotNull4() {
+
+    // Arrange
+    final StringBuilder buf = new StringBuilder("???");
+    final int dnsClass = 4;
+
+    // Act
+    final StringBuilder actual = DnsMessageUtil.appendRecordClass(buf, dnsClass);
+
+    // Assert side effects
+    Assert.assertNotNull(buf);
+    Assert.assertEquals("???HESIOD", buf.toString());
+
+    // Assert result
+    Assert.assertNotNull(actual);
+    Assert.assertEquals("???HESIOD", actual.toString());
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void appendRecordClassInputNotNullPositiveOutputNotNull5() {
+
+    // Arrange
+    final StringBuilder buf = new StringBuilder("???");
+    final int dnsClass = 2;
+
+    // Act
+    final StringBuilder actual = DnsMessageUtil.appendRecordClass(buf, dnsClass);
+
+    // Assert side effects
+    Assert.assertNotNull(buf);
+    Assert.assertEquals("???CSNET", buf.toString());
+
+    // Assert result
+    Assert.assertNotNull(actual);
+    Assert.assertEquals("???CSNET", actual.toString());
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void appendRecordClassInputNullPositiveOutputNullPointerException() {
+
+    // Arrange
+    final StringBuilder buf = null;
+    final int dnsClass = 3;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    DnsMessageUtil.appendRecordClass(buf, dnsClass);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void appendRecordClassInputNullPositiveOutputNullPointerException2() {
+
+    // Arrange
+    final StringBuilder buf = null;
+    final int dnsClass = 7;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    DnsMessageUtil.appendRecordClass(buf, dnsClass);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void appendRecordClassInputNullPositiveOutputNullPointerException3() {
+
+    // Arrange
+    final StringBuilder buf = null;
+    final int dnsClass = 255;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    DnsMessageUtil.appendRecordClass(buf, dnsClass);
+
+    // Method is not expected to return due to exception thrown
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void appendRecordClassInputNullPositiveOutputNullPointerException4() {
+
+    // Arrange
+    final StringBuilder buf = null;
+    final int dnsClass = 254;
+
+    // Act
+    thrown.expect(NullPointerException.class);
+    DnsMessageUtil.appendRecordClass(buf, dnsClass);
+
+    // Method is not expected to return due to exception thrown
+  }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FlagsTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FlagsTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+public class Http2FlagsTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Rule public final Timeout globalTimeout = new Timeout(10000);
+
+  /* testedClasses: Http2Flags */
+  // Test written by Diffblue Cover.
+  @Test
+  public void ackOutputFalse() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+
+    // Act
+    final boolean actual = objectUnderTest.ack();
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void ackOutputTrue() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)1);
+
+    // Act
+    final boolean actual = objectUnderTest.ack();
+
+    // Assert result
+    Assert.assertTrue(actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void endOfHeadersOutputFalse() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+
+    // Act
+    final boolean actual = objectUnderTest.endOfHeaders();
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void endOfHeadersOutputTrue() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)4);
+
+    // Act
+    final boolean actual = objectUnderTest.endOfHeaders();
+
+    // Assert result
+    Assert.assertTrue(actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void endOfStreamOutputFalse() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+
+    // Act
+    final boolean actual = objectUnderTest.endOfStream();
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void endOfStreamOutputTrue() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)1);
+
+    // Act
+    final boolean actual = objectUnderTest.endOfStream();
+
+    // Assert result
+    Assert.assertTrue(actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void equalsInputNullOutputFalse() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+    final Object obj = null;
+
+    // Act
+    final boolean actual = objectUnderTest.equals(obj);
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void getNumPriorityBytesOutputPositive() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)32);
+
+    // Act
+    final int actual = objectUnderTest.getNumPriorityBytes();
+
+    // Assert result
+    Assert.assertEquals(5, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void getNumPriorityBytesOutputZero() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+
+    // Act
+    final int actual = objectUnderTest.getNumPriorityBytes();
+
+    // Assert result
+    Assert.assertEquals(0, actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void getPaddingPresenceFieldLengthOutputPositive() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)8);
+
+    // Act
+    final int actual = objectUnderTest.getPaddingPresenceFieldLength();
+
+    // Assert result
+    Assert.assertEquals(1, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void getPaddingPresenceFieldLengthOutputZero() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+
+    // Act
+    final int actual = objectUnderTest.getPaddingPresenceFieldLength();
+
+    // Assert result
+    Assert.assertEquals(0, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void hashCodeOutputPositive() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+
+    // Act
+    final int actual = objectUnderTest.hashCode();
+
+    // Assert result
+    Assert.assertEquals(31, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void isFlagSetInputPositiveOutputFalse() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+    final short mask = (short)2;
+
+    // Act
+    final boolean actual = objectUnderTest.isFlagSet(mask);
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void isFlagSetInputPositiveOutputTrue() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)1);
+    final short mask = (short)1;
+
+    // Act
+    final boolean actual = objectUnderTest.isFlagSet(mask);
+
+    // Assert result
+    Assert.assertTrue(actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void paddingPresentOutputFalse() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+
+    // Act
+    final boolean actual = objectUnderTest.paddingPresent();
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void paddingPresentOutputTrue() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)8);
+
+    // Act
+    final boolean actual = objectUnderTest.paddingPresent();
+
+    // Assert result
+    Assert.assertTrue(actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void priorityPresentOutputFalse() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+
+    // Act
+    final boolean actual = objectUnderTest.priorityPresent();
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void priorityPresentOutputTrue() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)32);
+
+    // Act
+    final boolean actual = objectUnderTest.priorityPresent();
+
+    // Assert result
+    Assert.assertTrue(actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void toStringOutputNotNull() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags();
+
+    // Act
+    final String actual = objectUnderTest.toString();
+
+    // Assert result
+    Assert.assertEquals("value = 0 ()", actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void toStringOutputNotNull2() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)-8245);
+
+    // Act
+    final String actual = objectUnderTest.toString();
+
+    // Assert result
+    Assert.assertEquals("value = -8245 (ACK,END_OF_STREAM,PADDING_PRESENT,)", actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void toStringOutputNotNull3() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)-8211);
+
+    // Act
+    final String actual = objectUnderTest.toString();
+
+    // Assert result
+    Assert.assertEquals(
+        "value = -8211 (ACK,END_OF_HEADERS,END_OF_STREAM,PRIORITY_PRESENT,PADDING_PRESENT,)",
+        actual);
+  }
+
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void valueOutputZero() {
+
+    // Arrange
+    final Http2Flags objectUnderTest = new Http2Flags((short)0);
+
+    // Act
+    final short actual = objectUnderTest.value();
+
+    // Assert result
+    Assert.assertEquals((short)0, actual);
+  }
+}

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisCodecUtilTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisCodecUtilTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.redis;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+public class RedisCodecUtilTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Rule public final Timeout globalTimeout = new Timeout(10000);
+
+  /* testedClasses: RedisCodecUtil */
+  // Test written by Diffblue Cover.
+  @Test
+  public void longToAsciiBytesInputPositiveOutput1() {
+
+    // Arrange
+    final long value = 5L;
+
+    // Act
+    final byte[] actual = RedisCodecUtil.longToAsciiBytes(value);
+
+    // Assert result
+    Assert.assertArrayEquals(new byte[] {(byte)53}, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void makeShortInputNotNullNotNullOutputZero() {
+
+    // Arrange
+    final char first = '\u0000';
+    final char second = '\u0000';
+
+    // Act
+    final short actual = RedisCodecUtil.makeShort(first, second);
+
+    // Assert result
+    Assert.assertEquals((short)0, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void makeShortInputNotNullNotNullOutputZero2() {
+
+    // Arrange
+    final char first = '\u0000';
+    final char second = '\u0000';
+
+    // Act
+    final short actual = RedisCodecUtil.makeShort(first, second);
+
+    // Assert result
+    Assert.assertEquals((short)0, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void shortToBytesInputPositiveOutput2() {
+
+    // Arrange
+    final short value = (short)2;
+
+    // Act
+    final byte[] actual = RedisCodecUtil.shortToBytes(value);
+
+    // Assert result
+    Assert.assertArrayEquals(new byte[] {(byte)0, (byte)2}, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void shortToBytesInputZeroOutput2() {
+
+    // Arrange
+    final short value = (short)0;
+
+    // Act
+    final byte[] actual = RedisCodecUtil.shortToBytes(value);
+
+    // Assert result
+    Assert.assertArrayEquals(new byte[] {(byte)0, (byte)0}, actual);
+  }
+}


### PR DESCRIPTION
Motivation:

Hi,

I've analysed your code base and noticed that 
`codec-dns.src.test.java.io.netty.handler.codec.dns.DnsMessageUtil`
`codec-http2.src.test.java.io.netty.handler.codec.http2.Http2Flags` 
`codec-redis.src.test.java.io/netty.handler.codec.redis.RedisCodecUtil` are not fully tested.

Modification:

I've written some tests that cover these classes with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Result:

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.
